### PR TITLE
Copy nvm dir to bundled output

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -69,3 +69,10 @@ fi
 
 cd $CURRENT_DIR
 cp -R $INPUT_DIR/. $OUTPUT_DIR
+
+MOD_DIR=$OUTPUT_DIR/.modulus
+mkdir -p $MOD_DIR
+
+# bundle nvm with output
+nvm alias deploy $(nvm current)
+cp -R $NVM_DIR/. $MOD_DIR/nvm


### PR DESCRIPTION
removes need to install specific node/npm versions in run image 
