### PR TITLE
Enforce sourcing `nvm`

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -16,6 +16,9 @@ if [[ ! -d $INPUT_DIR ]] || [[ ! -d $OUTPUT_DIR ]]; then
   exit 1
 fi
 
+NVM_DIR=$HOME/.nvm
+source /opt/nvm/nvm.sh
+
 # recursively search input directory for a package.json
 PACKAGE_PATH=$(find $INPUT_DIR -name package.json ! -path "*/node_modules/*"  ! -path ".git/*"  | \
   awk -F'/' '{print $0 "," NF-1}' | \
@@ -25,9 +28,6 @@ PACKAGE_PATH=$(find $INPUT_DIR -name package.json ! -path "*/node_modules/*"  ! 
 if [[ $PACKAGE_PATH ]]; then
   printf "Package found: ${PACKAGE_PATH/$INPUT_DIR/}\n"
   export PACKAGE_PATH
-
-  NVM_DIR=$HOME/.nvm
-  source /opt/nvm/nvm.sh
 
   # support deriving versions from app.json or package.json
   if [ -f ${INPUT_DIR}/app.json ] && [[ $MODULUS_CONFIG_ENGINES_NODE || $MODULUS_CONFIG_ENGINES_IOJS ]]; then


### PR DESCRIPTION
This fixes an issue where `nvm` would not be loaded if a package path
is not found (such as when deploying 'simple' project directories).
