### PR TITLE
Move input to output, instead of copy

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -68,7 +68,8 @@ if [[ $PACKAGE_PATH ]]; then
 fi
 
 cd $CURRENT_DIR
-cp -R $INPUT_DIR/. $OUTPUT_DIR
+# Move all the files in Input Dir to Outpup Dir.  Include dot files
+mv $INPUT_DIR/{*,.*} $OUTPUT_DIR > /dev/null 2>&1
 
 MOD_DIR=$OUTPUT_DIR/.modulus
 mkdir -p $MOD_DIR


### PR DESCRIPTION
Add -y flage to apt-get autoremove.  If a program is to be removed, the
flag needs to be set or else apt-get will request input, causing the
script to end.

Also move the input dir to output dir when building.  This reduces the needed size of the build by half as we won't be copying the input to output.
