### PR TITLE
install expect dependency

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,6 +8,9 @@ export TEMP_DIR=/tmp
 export TMPDIR=/tmp
 export TMP_DIR=/tmp
 
+# install expect
+apt-get install -y expect
+
 # install nvm
 export NVM_DIR=/opt/nvm
 mkdir -p $NVM_DIR


### PR DESCRIPTION
Installs the `expect` dependency. This is needed to log into npm via `npm-login`

Closes #13 